### PR TITLE
fix: 修复剩余 3 个安全告警

### DIFF
--- a/pedestal-core/anc-parent/pom.xml
+++ b/pedestal-core/anc-parent/pom.xml
@@ -45,7 +45,7 @@
         <msgpack.version>0.6.12</msgpack.version>
         <!--工具-->
         <jackson-databind.version>2.18.3</jackson-databind.version>
-        <commons-lang3.version>3.17.0</commons-lang3.version>
+        <commons-lang3.version>3.18.0</commons-lang3.version>
         <commons-pool2.version>2.6.2</commons-pool2.version>
         <commons-collections4.version>4.4</commons-collections4.version>
         <commons-io.version>2.6</commons-io.version>
@@ -56,6 +56,7 @@
         <commons-math3.version>3.6.1</commons-math3.version>
         <google.guava.version>33.4.8-jre</google.guava.version>
         <google-gson.version>2.13.1</google-gson.version>
+        <gson.version>2.13.1</gson.version>
         <guava-retrying.version>2.0.0</guava-retrying.version>
         <hutool.version>5.8.36</hutool.version>
         <fastjson.version>2.0.58</fastjson.version>

--- a/pedestal-infrastructure/pedestal-inf-oss/pom.xml
+++ b/pedestal-infrastructure/pedestal-inf-oss/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>io.minio</groupId>
             <artifactId>minio</artifactId>
-            <version>8.5.17</version>
+            <version>8.6.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Summary
- 升级 minio 8.5.17 → 8.6.0 (High: XML Tag Value Substitution)
- 升级 commons-lang3 3.17.0 → 3.18.0 (Medium: Uncontrolled Recursion)  
- 覆盖 Spring Boot BOM 的 gson 版本为 2.13.1 (High: Deserialization)

## Test plan
- [x] `mvn compile` 全部模块编译成功
- [ ] 合并后确认 GitHub Security 告警清零

🤖 Generated with [Claude Code](https://claude.com/claude-code)