### PR TITLE
fix: 修复最后一个 gson 安全告警

### DIFF
--- a/pedestal-infrastructure/pedestal-api-gateway/pom.xml
+++ b/pedestal-infrastructure/pedestal-api-gateway/pom.xml
@@ -51,12 +51,10 @@
         <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
-            <version>2.10.9</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.6</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
## Summary
- 移除 api-gateway 中硬编码的 gson 2.8.6 版本，改用 dependencyManagement 管理的 2.13.1
- 同步移除硬编码的 joda-time 2.10.9，改用统一管理的 2.14.0

## Test plan
- [x] `mvn compile` 编译成功
- [ ] 合并后确认 GitHub Security 告警清零

🤖 Generated with [Claude Code](https://claude.com/claude-code)